### PR TITLE
fix(windows): use “;” + \Scripts when prepending venv to PATH

### DIFF
--- a/lua/uv/init.lua
+++ b/lua/uv/init.lua
@@ -80,15 +80,16 @@ end
 
 -- Virtual environment activation
 function M.activate_venv(venv_path)
-	-- For Mac, run the source command to apply to the current shell
-	local command = "source " .. venv_path .. "/bin/activate"
-	-- Set environment variables for the current Neovim instance
-	vim.env.VIRTUAL_ENV = venv_path
-	vim.env.PATH = venv_path .. "/bin:" .. vim.env.PATH
-	-- Notify user
-	if M.config.notify_activate_venv then
-		vim.notify("Activated virtual environment: " .. venv_path, vim.log.levels.INFO)
-	end
+        local is_windows = package.config:sub(1, 1) == '\\'
+        local venv_dir = is_windows and 'Scripts' or 'bin'
+        local sep = is_windows and ';' or ':'
+
+        vim.env.VIRTUAL_ENV = venv_path
+        vim.env.PATH = venv_path .. '/' .. venv_dir .. sep .. vim.env.PATH
+
+        if M.config.notify_activate_venv then
+                vim.notify("Activated virtual environment: " .. venv_path, vim.log.levels.INFO)
+        end
 end
 
 -- Auto-activate the .venv if it exists at the project root


### PR DESCRIPTION
### Problem

On Windows, `uv.nvim` prepends the virtual‑env path to `PATH` like this:
D:\proj.venv/bin:C:\Users\me\AppData\Local\nvim-data\mason\bin;...

