### PR TITLE
Add user commands for adding and removing packages

### DIFF
--- a/lua/uv/init.lua
+++ b/lua/uv/init.lua
@@ -741,6 +741,16 @@ function M.setup_commands()
 	vim.api.nvim_create_user_command("UVRunFile", function()
 		M.run_file()
 	end, {})
+
+	-- Command to add a package
+	vim.api.nvim_create_user_command("UVAddPackage", function(opts)
+		M.run_command("uv add " .. opts.args)
+	end, { nargs = 1 })
+
+	-- Command to remove a package
+	vim.api.nvim_create_user_command("UVRemovePackage", function(opts)
+		M.run_command("uv remove " .. opts.args)
+	end, { nargs = 1 })
 end
 
 -- Set up keymaps
@@ -880,6 +890,7 @@ function M.setup_keymaps()
 		)
 	end
 end
+
 -- Set up auto commands
 function M.setup_autocommands()
 	if M.config.auto_commands then


### PR DESCRIPTION
It's nice to have simple user commands to add/remove packages instead of relying on keybinds or manually running `require('uv').run_command('uv add foo')`.