### PR TITLE
Feat/improve command preview in snacks picker

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.lua]
+indent_style = tab

--- a/lua/uv/init.lua
+++ b/lua/uv/init.lua
@@ -471,6 +471,14 @@ function M.setup_pickers()
 					{ text = "uv init", desc = "Initialize a new project" },
 				}
 			end,
+			preview = function(ctx)
+				local cmd = ctx.item.text:match("^(uv %a+)")
+				if cmd then
+					Snacks.picker.preview.cmd(cmd .. " --help", ctx)
+				else
+					ctx.preview:set_lines({})
+				end
+			end,
 			format = function(item)
 				return { { item.text .. " - " .. item.desc } }
 			end,


### PR DESCRIPTION
Hi Ben, we've just started using UV in our team and I'm testing your plugin. Here's a little improvement for the Snacks picker:
- The preview shows the `uv COMMAND --help` output instead of an error message.

Apart from that, I've added the `.editorconfig` file to instruct Neovim to use tabs in `lua/uv/init.lua` (useful for people like me who set `vim.o.expandtab = true`).

Thanks for considering this contribution.