### PR TITLE
README: added dependencies to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 ```lua
 return {
   "benomahony/uv.nvim",
+  -- Optional dependency, but recommended:
+  -- dependencies = {
+  --   "folke/snacks.nvim"
+  -- or
+  --   "nvim-telescope/telescope.nvim"
+  -- },
   opts = {
     picker_integration = true,
   },
@@ -33,6 +39,12 @@ Using [packer.nvim](https://github.com/wbthomason/packer.nvim):
 ```lua
 use {
   'benomahony/uv.nvim',
+  -- Optional dependency, but recommended:
+  -- requires = {
+  --   "folke/snacks.nvim"
+  -- or
+  --   "nvim-telescope/telescope.nvim"
+  -- },
   config = function()
     require('uv').setup()
   end


### PR DESCRIPTION
Instead of listing that snacks and telescope are possible and having to go to their website, just include it. People are lazy and don't want to go find the website, it can be an easy reminder when setting up to use some of your nice features, or just as a gentle reminder that these are the only things that work with the plugin.